### PR TITLE
Update docker run example with --name requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ Openbooks allows you to download ebooks from irc.irchighway.net quickly and easi
 
 ### Docker
 
+Replace `some_username` with your own below.
+
 - Basic config
-  - `docker run -p 8080:80 evanbuss/openbooks`
+  - `docker run -p 8080:80 evanbuss/openbooks --name some_username`
 - Config to persist all eBook files to disk
-  - `docker run -p 8080:80 -v /home/evan/Downloads/openbooks:/books evanbuss/openbooks --persist`
+  - `docker run -p 8080:80 -v /home/evan/Downloads/openbooks:/books evanbuss/openbooks --persist --name some_username`
 
 ### Setting the Base Path
 


### PR DESCRIPTION
Not 100% sure but I think I was able to use openbooks without the --name argument some time ago — I came back to it today and my containers didn't start as I left my config (I use declarative container config w/ Nix) — logs revealed the --name argument is now a requirement.

I think this might block more novice users (I know, I know, there is the --help), and for sake of simplicity it should be included in the Docker example.